### PR TITLE
Make sure `cloth-mask` image has greyscale mode `L`

### DIFF
--- a/cp_dataset_test.py
+++ b/cp_dataset_test.py
@@ -120,7 +120,7 @@ class CPDatasetTest(data.Dataset):
             c_name[key] = self.c_names[key][index]
             c[key] = Image.open(osp.join(self.data_path, 'cloth', c_name[key])).convert('RGB')
             c[key] = transforms.Resize(self.fine_width, interpolation=2)(c[key])
-            cm[key] = Image.open(osp.join(self.data_path, 'cloth-mask', c_name[key]))
+            cm[key] = Image.open(osp.join(self.data_path, 'cloth-mask', c_name[key])).convert('L')
             cm[key] = transforms.Resize(self.fine_width, interpolation=0)(cm[key])
 
             c[key] = self.transform(c[key])  # [-1,1]


### PR DESCRIPTION
This could come in handy when the mask image is saved as RGB